### PR TITLE
Add links to issue template

### DIFF
--- a/ISSUE_TEMPLATE/new_campaign.md
+++ b/ISSUE_TEMPLATE/new_campaign.md
@@ -1,8 +1,8 @@
 ___ DELETE ___
 
-[click here to create a new campaign tracking_issue](https://github.com/rust-community/content-o-tron/issues/new?template=new_campaign.md&title=Tracking:+__NAME_OF_CAMPAIGN__&labels=campaign)
+Are you new to running a blogging campaign? Then have a look at our handy [guide](https://github.com/rust-community/content-o-tron/blob/master/guides/running_a_campaign.md) to learn more.
 
-[Have a look at the Running a blog post campaign](https://github.com/rust-community/content-o-tron/blob/master/guides/running_a_campaign.md)
+[click here to create a new campaign tracking_issue](https://github.com/rust-community/content-o-tron/issues/new?template=new_campaign.md&title=Tracking:+__NAME_OF_CAMPAIGN__&labels=campaign)
 
 ___ DELETE ___
 

--- a/ISSUE_TEMPLATE/new_campaign.md
+++ b/ISSUE_TEMPLATE/new_campaign.md
@@ -2,6 +2,8 @@ ___ DELETE ___
 
 [click here to create a new campaign tracking_issue](https://github.com/rust-community/content-o-tron/issues/new?template=new_campaign.md&title=Tracking:+__NAME_OF_CAMPAIGN__&labels=campaign)
 
+[Have a look at the Running a blog post campaign](https://github.com/rust-community/content-o-tron/blob/master/guides/running_a_campaign.md)
+
 ___ DELETE ___
 
 Please link to your posts or drafts (PRs are fine) here via comments.


### PR DESCRIPTION
**Resolves**: #41

**Relevant Screenshot**:
![cot_issue41](https://user-images.githubusercontent.com/19192257/40575857-58294d36-610a-11e8-9540-c19cbe98a626.JPG)

**Task accomplished**: The user can now click on the link and would be directed to the **Running a blog post campaign page**.

**Type of change**: Markdown